### PR TITLE
Fix the "Use relative imports" check

### DIFF
--- a/.relint.yml
+++ b/.relint.yml
@@ -11,5 +11,5 @@
   filePattern: ^(?!.*conftest).*\.py$
 
 - name: Use relative imports
-  pattern: "import schemathesis|from schemathesis"
+  pattern: "import har2tavern|from har2tavern"
   filePattern: "src/.*.py$"


### PR DESCRIPTION
Hi @dongfangtianyu !

It looks like the relint config uses the wrong module name :) This PR fixes that